### PR TITLE
Switch to tensorflow.keras

### DIFF
--- a/Keras_Implementation/AutoencoderModel.py
+++ b/Keras_Implementation/AutoencoderModel.py
@@ -6,11 +6,11 @@ Created on Mon Dec  9 14:31:29 2019
 Wrapper File for 1. Compute pwr combined (Real, Imag), (Extract R & I parts) Generate single distribution, Separate Sending, (R&I)
 """
 
-from keras.layers import Conv2D, Layer, Input, Conv2DTranspose, UpSampling2D, Cropping2D
-from keras.optimizers import Adam
-from keras.layers.advanced_activations import PReLU
-from keras.models import Model
-import keras
+from tensorflow.keras.layers import Conv2D, Layer, Input, Conv2DTranspose, UpSampling2D, Cropping2D
+from tensorflow.keras.optimizers import Adam
+from tensorflow.keras.layers import PReLU
+from tensorflow.keras.models import Model
+import tensorflow.keras as keras
 import tensorflow as tf
 import numpy as np
 import tensorflow.keras.backend as K
@@ -173,9 +173,9 @@ def TrainAutoEncoder(x_train, x_test, nb_epoch, comp_ratio, batch_size, c, snr, 
     print('\t|\t\t\t\t\t\t\t\t|')
     print('\t|\t\t\t\t\t\t\t\t|')
     print('\t-----------------------------------------------------------------')
-    tb = keras.callbacks.tensorboard_v1.TensorBoard(log_dir='./Tensorboard/CompRatio{0}_SNR{1}'.format(str(comp_ratio), str(snr)))
+    tb = keras.callbacks.TensorBoard(log_dir='./Tensorboard/CompRatio{0}_SNR{1}'.format(str(comp_ratio), str(snr)))
     os.makedirs('./checkpoints/CompRatio{0}_SNR{1}'.format(str(comp_ratio), str(snr)), exist_ok=True)
-    checkpoint = keras.callbacks.callbacks.ModelCheckpoint(filepath='./checkpoints/CompRatio{0}_SNR{1}'.format(str(comp_ratio), str(snr))+'/Autoencoder.h5', monitor='val_loss', save_best_only=True)
+    checkpoint = keras.callbacks.ModelCheckpoint(filepath='./checkpoints/CompRatio{0}_SNR{1}'.format(str(comp_ratio), str(snr))+'/Autoencoder.h5', monitor='val_loss', save_best_only=True)
     ckpt = ModelCheckponitsHandler(comp_ratio, snr, autoencoder, step=saver_step)
     history = autoencoder.fit(x=x_train, y=x_train, batch_size=batch_size, epochs=nb_epoch,  callbacks=[tb, checkpoint, ckpt], validation_data=(x_test,x_test))
     return history

--- a/Keras_Implementation/AutoencoderTrain.py
+++ b/Keras_Implementation/AutoencoderTrain.py
@@ -6,7 +6,7 @@ Created on Wed Nov 20 00:39:40 2019
 1. Compute pwr combined (Real, Imag), (Extract R & I parts) Generate single distribution, Separate Sending, (R&I)
 """
 
-from keras.datasets import cifar10
+from tensorflow.keras.datasets import cifar10
 from AutoencoderModel import TrainAutoEncoder, Calculate_filters
 import tensorflow as tf
 

--- a/Keras_Implementation/Autoencoder_Evaluation.py
+++ b/Keras_Implementation/Autoencoder_Evaluation.py
@@ -8,10 +8,10 @@ Created on Thu Dec 12 20:57:10 2019
 import tensorflow as tf
 import os
 import numpy as np
-from keras.models import load_model
+from tensorflow.keras.models import load_model
 from AutoencoderModel import NormalizationNoise
-from keras.datasets import cifar10
-from keras import backend as K
+from tensorflow.keras.datasets import cifar10
+from tensorflow.keras import backend as K
 from skimage.metrics import structural_similarity
 from skimage.measure import compare_psnr 
 from matplotlib import pyplot as plt

--- a/Tensorflow_Implementation/Evaluate_Model.py
+++ b/Tensorflow_Implementation/Evaluate_Model.py
@@ -6,7 +6,7 @@ Created on Tue Nov 26 18:09:44 2019
 """
 
 import tensorflow as tf
-from keras.datasets import cifar10
+from tensorflow.keras.datasets import cifar10
 from JSCC_Methods import Normalize_pixels
 from JSCC_visualization import  Get_PlotBySNR, Get_PlotByCompRatio, load_modelHistories
 #from JSCC_visualization import load_model, get_pred, get_PSNR, read_json

--- a/Tensorflow_Implementation/JSCC_Main.py
+++ b/Tensorflow_Implementation/JSCC_Main.py
@@ -6,7 +6,7 @@ Created on Fri Nov 22 00:57:21 2019
 """
 
 import numpy as np
-from keras.datasets import cifar10
+from tensorflow.keras.datasets import cifar10
 import tensorflow as tf
 from JSSC_wrapper import conv2d_layer, conv2dTranspose_layer, PReLU, CompileModel, GetAccuracy, WriteSummaries, TrainModel
 from JSCC_Methods import Normalize_pixels, NormalizationLayer, AWGN_layer, Calculate_filters

--- a/Tensorflow_Implementation/JSCC_Main_Auto.py
+++ b/Tensorflow_Implementation/JSCC_Main_Auto.py
@@ -6,7 +6,7 @@ Created on Fri Nov 22 00:57:21 2019
 """
 
 import numpy as np
-from keras.datasets import cifar10
+from tensorflow.keras.datasets import cifar10
 import tensorflow as tf
 from JSSC_wrapper import conv2d_layer, conv2dTranspose_layer, PReLU, CompileModel, GetAccuracy, WriteSummaries, TrainModel
 from JSCC_Methods import Normalize_pixels, NormalizationLayer, AWGN_layer, Calculate_filters


### PR DESCRIPTION
## Summary
- replace keras imports with tensorflow.keras
- update callback paths for new import names
- keep repo clean of keras references

## Testing
- `python Keras_Implementation/AutoencoderTrain.py` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68634cd6c51c8330b5d36e7324b49894